### PR TITLE
fix: empty import.meta with target es2019

### DIFF
--- a/examples/i18n/tsconfig.json
+++ b/examples/i18n/tsconfig.json
@@ -3,7 +3,7 @@
 		"moduleResolution": "node",
 		"module": "es2020",
 		"lib": ["es2020", "DOM"],
-		"target": "es2019",
+		"target": "es2020",
 		/**
 			svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript
 			to enforce using \`import type\` instead of \`import\` for Types.


### PR DESCRIPTION
I've tested `examples/i18n` with `adapter-node` and it generally works fine. Nevertheless, I was facing the following error on trying to build the example:

```
> Using @sveltejs/adapter-node
 > .svelte-kit/node/middlewares.js:437:40: warning: "import.meta" is not available in the configured target environment ("es2019") and will be empty
    437 │ const __dirname = dirname(fileURLToPath(import.meta.url));
        ╵                                         ~~~~~~~~~~~
   tsconfig.json:6:12: note: The target environment was set to "es2019" here
      6 │     "target": "es2019",
        ╵               ~~~~~~~~
```

Therefor this PR updates tsconfig.json to use `target: es2020`.